### PR TITLE
Add missing closing div element causing mis-rendering

### DIFF
--- a/src/PKMNPostGame.Web/xy_checklist.html
+++ b/src/PKMNPostGame.Web/xy_checklist.html
@@ -10,7 +10,7 @@
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 	<link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css">
 	<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
-	
+
 	<!-- Bootstrap -->
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap-theme.min.css">
@@ -24,23 +24,23 @@
 
 	<script src="js/build_menu.js"></script>
 	<script src="js/postgame_checklist2.js"></script>
-	
+
 	<script>
 		$(function()
 		{
 			BuildMenu();
 			Render("xy","data/xy_postgame_checklist.json", "xypost");
-			
-			$(".postgame_chkLabel[title]" ).tooltip({});			
-			
+
+			$(".postgame_chkLabel[title]" ).tooltip({});
+
 			$(".postgame_chk").on('click', function(e) {
 				chk_onClick(e, "xypost");
 			});
-			
+
 			LoadCollapseState("xy");
 
 			ChangeSpanToImages("xy");
-		});		
+		});
 	</script>
 
 	<script>
@@ -78,7 +78,7 @@
         <div id="navbar" class="collapse navbar-collapse"></div>
       </div>
     </nav>
-	
+
 	<div class="postgame container-fluid">
 		<div id="row1" class="row">
 			<div class="pageTitle col-sm-12 col-xs-12">
@@ -89,7 +89,7 @@
 				<span style="font-weight: bold; font-size:12pt">See a problem or issue? Let me know on Twitter <a href="https://twitter.com/PokemonPostGame">@PokemonPostGame</a></span><br/>
 				or via email: <a href="mailto:PkmnPostGame@gmail.com">PkmnPostGame@gmail.com</a><br/>
 			</div>
-			
+
 		</div>
 		<div id="row2" class="row row-header">
 			<div class="col-lg-offset-1 col-sm-3 col-xs-6">
@@ -109,7 +109,7 @@
 					<span class="badge-sm xyPsychicBadge" alt="Psychic Badge" ></span>
 					<span class="badge-sm xyIcebergBadge" alt="Iceberg Badge" ></span>
 				</div>
-			</div>			
+			</div>
 		</div>
 		<div class="row">
 			<div class="col-sm-offset-1 col-xs-11">
@@ -174,6 +174,7 @@
 							</div>
 						</div>
 					</div>
+				</div>
 				<div class="panel-group megastones">
 					<div class="panel panel-default">
 						<div class="panel-heading">


### PR DESCRIPTION
Adds a missing `</div>` which was causing a rendering issue, causing sections to be nested improperly.

**Before**

<img width="453" alt="Screenshot 2019-10-24 at 00 29 02" src="https://user-images.githubusercontent.com/129327/67441595-601fcc00-f5f5-11e9-83a6-57f97dc03c71.png">

**After**

<img width="463" alt="Screenshot 2019-10-24 at 00 30 20" src="https://user-images.githubusercontent.com/129327/67441618-7ded3100-f5f5-11e9-8a35-4e8a0bef3d4a.png">
