### PR TITLE
Dead images

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
 					<p>Sections can be expanded or collapsed by clicking the section title next to the chevron ( <span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span> ).</p>
 					<p class="newsflash">
 						<span class="label label-default label-new">New!</span>
-						<img src="http://dev.spicyeyes.com/GitHub/PokemonChecklists/src/PKMNPostGame.Web/images/pokeball_bullet.png"/>
+						<img src="src/PKMNPostGame.Web/images/pokeball_bullet.png"/>
 						Check out the newly added list for <a href="src/PKMNPostGame.Web/xd_checklist.html">Pokemon XD Gale of Darkness Completion Checklist</a>
 					</p>
 				</div>


### PR DESCRIPTION
I was trying to find and replace the broken image links for the other stuff, but its 6am and im lost in the code.

All the images on the Sword and Shield page are dead linking to 
http://pokemonpostgame.com/src/images/swsh_shield.png
instead of 
http://pokemonpostgame.com/src/PKMNPostGame.Web/images/swsh_shield.png

I'm guessing something broke somewhere and needs some cleanup