### PR TITLE
Update xd_postgame_checklist.json

### DIFF
--- a/src/PKMNPostGame.Web/data/xd_postgame_checklist.json
+++ b/src/PKMNPostGame.Web/data/xd_postgame_checklist.json
@@ -113,7 +113,9 @@
 			{"id":"sub11", "task":"Zubat", "tooltip":"Cave Spot"},
 			{"id":"sub12", "task":"Aron", "tooltip":"Cave Spot"},
 			{"id":"sub13", "task":"Wooper", "tooltip":"Cave Spot"},
-			{"id":"sub14", "task":"Chikorita, Cyndaquil, or Totodile", "tooltip":"Defeat the Mt. Battle Challenge (100 Trainers) - Choose one"}
+			{"id":"sub14", "task":"Chikorita", "tooltip":"Defeat the Mt. Battle Challenge (100 Trainers) and choose Chikorita"},
+			{"id":"sub15", "task":"Cyndaquil", "tooltip":"Defeat the Mt. Battle Challenge (100 Trainers) and choose Cyndaquil"},
+			{"id":"sub16", "task":"Totodile", "tooltip":"Defeat the Mt. Battle Challenge (100 Trainers) and choose Totodile"}
 		]
 	},
 	{"id":"task10",


### PR DESCRIPTION
Update task to Catch all non-shadow pokemon to include a separate entry for each starter as you can defeat the Mt. Battle Challenge multiple times and pick a different starter each time.  Thanks to Reqhzi for the tip/correction.